### PR TITLE
nightshift: code-quality — refactor update_readme_stats.py

### DIFF
--- a/update_readme_stats.py
+++ b/update_readme_stats.py
@@ -8,33 +8,50 @@ from selenium.webdriver.support.ui import WebDriverWait
 from selenium.webdriver.support import expected_conditions as EC
 from selenium.common.exceptions import TimeoutException, WebDriverException
 from bs4 import BeautifulSoup
-import time
 from datetime import datetime, timezone
-
-# --- Helper function for debugging ---
-def log_and_flush(message):
-    """Prints a message and flushes stdout to ensure it appears in logs immediately."""
-    print(message)
-    sys.stdout.flush()
 
 # --- Configuration ---
 GAMEBANANA_URL = "https://gamebanana.com/mods/486547"
 SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
-REPO_DIR = SCRIPT_DIR
-README_PATH = os.path.join(REPO_DIR, "README.md")
-USER_AGENT = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/108.0.0.0 Safari/537.36"
+README_PATH = os.path.join(SCRIPT_DIR, "README.md")
+USER_AGENT = (
+    "Mozilla/5.0 (Windows NT 10.0; Win64; x64) "
+    "AppleWebKit/537.36 (KHTML, like Gecko) Chrome/108.0.0.0 Safari/537.36"
+)
 PLACEHOLDERS = {
     "downloads": "<!-- GB_DOWNLOADS -->",
     "views": "<!-- GB_VIEWS -->",
     "likes": "<!-- GB_LIKES -->",
     "timestamp": "<!-- LAST_UPDATED -->",
 }
+STAT_SELECTORS = {
+    "likes": ("LikeCount", "likes"),
+    "downloads": ("DownloadCount", "downloads"),
+    "views": ("ViewCount", "views"),
+}
 # --- End Configuration ---
 
+
+def log_and_flush(message):
+    """Print a message and flush stdout to ensure it appears in logs immediately."""
+    print(message)
+    sys.stdout.flush()
+
+
+def _extract_stat(stats_module, css_class, key):
+    """Extract a single stat value from the GameBanana stats module."""
+    li = stats_module.find("li", class_=css_class)
+    if li:
+        tag = li.find("itemcount")
+        if tag:
+            return key, tag.text.strip()
+    return None
+
+
 def scrape_stats(url):
-    """Fetches the Gamebanana page using Selenium and extracts stats."""
+    """Fetch the GameBanana page using Selenium and extract stats."""
     log_and_flush(f"--- Starting scrape_stats for URL: {url} ---")
-    
+
     log_and_flush("Configuring Chrome options...")
     chrome_options = Options()
     chrome_options.add_argument(f"user-agent={USER_AGENT}")
@@ -43,14 +60,14 @@ def scrape_stats(url):
     chrome_options.add_argument("--disable-dev-shm-usage")
     chrome_options.add_argument("--disable-gpu")
     chrome_options.add_argument("--window-size=1920,1080")
-    chrome_options.add_experimental_option('excludeSwitches', ['enable-logging'])
-    chrome_options.add_argument('--log-level=3')
+    chrome_options.add_experimental_option("excludeSwitches", ["enable-logging"])
+    chrome_options.add_argument("--log-level=3")
     log_and_flush("Chrome options configured.")
-    
+
     driver = None
+    stats = {}
     try:
         log_and_flush("Attempting to initialize WebDriver...")
-        # THIS IS A LIKELY PLACE TO HANG
         driver = webdriver.Chrome(options=chrome_options)
         log_and_flush("WebDriver initialized successfully.")
 
@@ -59,7 +76,6 @@ def scrape_stats(url):
         log_and_flush("Page load timeout set.")
 
         log_and_flush(f"Sending driver.get() command to: {url}")
-        # THIS IS THE SECOND MOST LIKELY PLACE TO HANG
         driver.get(url)
         log_and_flush("driver.get() command completed. Page load initiated.")
 
@@ -69,27 +85,17 @@ def scrape_stats(url):
         )
         log_and_flush("StatsModule found. Proceeding with scraping.")
 
-        page_source = driver.page_source
-        soup = BeautifulSoup(page_source, "html.parser")
-        stats = {}
-        stats_module = soup.find('module', id='StatsModule')
-        if stats_module:
-            log_and_flush("Found StatsModule container.")
-            like_li = stats_module.find('li', class_='LikeCount')
-            if like_li:
-                itemcount_tag = like_li.find('itemcount')
-                if itemcount_tag: stats['likes'] = itemcount_tag.text.strip()
-            download_li = stats_module.find('li', class_='DownloadCount')
-            if download_li:
-                itemcount_tag = download_li.find('itemcount')
-                if itemcount_tag: stats['downloads'] = itemcount_tag.text.strip()
-            view_li = stats_module.find('li', class_='ViewCount')
-            if view_li:
-                itemcount_tag = view_li.find('itemcount')
-                if itemcount_tag: stats['views'] = itemcount_tag.text.strip()
-        else:
+        soup = BeautifulSoup(driver.page_source, "html.parser")
+        stats_module = soup.find("module", id="StatsModule")
+        if not stats_module:
             log_and_flush("ERROR: Could not find the main stats module (id='StatsModule').")
             return None
+
+        log_and_flush("Found StatsModule container.")
+        for css_class, key in STAT_SELECTORS.values():
+            result = _extract_stat(stats_module, css_class, key)
+            if result:
+                stats[result[0]] = result[1]
 
     except TimeoutException as e:
         log_and_flush(f"ERROR: A timeout occurred. The page or element did not load in time: {e}")
@@ -106,59 +112,76 @@ def scrape_stats(url):
             driver.quit()
 
     log_and_flush(f"Scraped stats: {stats}")
-    if not stats or not all(k in stats for k in ["downloads", "views", "likes"]):
+    required_keys = ["downloads", "views", "likes"]
+    if not stats or not all(k in stats for k in required_keys):
         log_and_flush("ERROR: Failed to find all required stats.")
         return None
     return stats
 
+
 def update_readme(readme_path, stats_data):
-    """Reads the README, replaces placeholders, and writes back if changed."""
+    """Read the README, replace placeholders, and write back if changed."""
     log_and_flush(f"Updating README: {readme_path}")
     if not os.path.exists(readme_path):
         log_and_flush(f"ERROR: README file not found at {readme_path}")
         return False
     try:
-        with open(readme_path, 'r', encoding='utf-8') as f: readme_content = f.read()
+        with open(readme_path, "r", encoding="utf-8") as f:
+            readme_content = f.read()
     except Exception as e:
         log_and_flush(f"Error reading README file: {e}")
         return False
-    original_content = readme_content; changes_made = False
+
+    original_content = readme_content
+    changes_made = False
     for key, placeholder in PLACEHOLDERS.items():
         if key in stats_data and stats_data[key] is not None:
             pattern = re.compile(f"({re.escape(placeholder)})\\s*([^\\n<]+)")
             new_text = f"{placeholder} {stats_data[key]}"
             readme_content, num_subs = pattern.subn(new_text, readme_content)
-            if num_subs > 0: log_and_flush(f"  Updated {key} to {stats_data[key]}"); changes_made = True
-            elif key != 'timestamp': log_and_flush(f"  Placeholder {placeholder} not found or pattern mismatch.")
-        elif key != 'timestamp': log_and_flush(f"  Stat '{key}' not found in scraped data.")
+            if num_subs > 0:
+                log_and_flush(f"  Updated {key} to {stats_data[key]}")
+                changes_made = True
+            elif key != "timestamp":
+                log_and_flush(f"  Placeholder {placeholder} not found or pattern mismatch.")
+        elif key != "timestamp":
+            log_and_flush(f"  Stat '{key}' not found in scraped data.")
+
     if changes_made and readme_content != original_content:
         log_and_flush("Changes detected, writing updated README...")
         try:
-            with open(readme_path, 'w', encoding='utf-8') as f: f.write(readme_content)
-            log_and_flush("README update successful."); return True
-        except IOError as e: log_and_flush(f"Error writing updated README: {e}"); return False
-    else: log_and_flush("No changes needed in README."); return False
+            with open(readme_path, "w", encoding="utf-8") as f:
+                f.write(readme_content)
+            log_and_flush("README update successful.")
+            return True
+        except IOError as e:
+            log_and_flush(f"Error writing updated README: {e}")
+            return False
+    else:
+        log_and_flush("No changes needed in README.")
+        return False
+
 
 # --- Main Execution Block ---
 if __name__ == "__main__":
     log_and_flush(f"Starting README stats update process at {datetime.now()}...")
-    
+
     scraped_data = scrape_stats(GAMEBANANA_URL)
 
     if scraped_data:
         now_utc = datetime.now(timezone.utc)
         timestamp_str = now_utc.strftime("%Y-%m-%d %H:%M:%S UTC")
-        scraped_data['timestamp'] = timestamp_str
+        scraped_data["timestamp"] = timestamp_str
         log_and_flush(f"Generated timestamp: {timestamp_str}")
 
         readme_changed = update_readme(README_PATH, scraped_data)
 
         if readme_changed:
             log_and_flush("README was updated. The workflow will now commit and push the changes.")
-            sys.exit(0) # Success
+            sys.exit(0)  # Success
         else:
             log_and_flush("No changes were made to the README.")
-            sys.exit(0) # Success, but nothing to do
+            sys.exit(0)  # Success, but nothing to do
     else:
         log_and_flush("Failed to scrape stats, README not updated.")
-        sys.exit(1) # Error
+        sys.exit(1)  # Error


### PR DESCRIPTION
## Code Quality Improvements for `update_readme_stats.py`

### Changes

- **Remove unused `time` import** — was imported but never referenced
- **Eliminate redundant `REPO_DIR` variable** — identical to `SCRIPT_DIR`, adds no semantic value
- **Extract duplicated stat parsing into `_extract_stat()` helper** — the like/download/view extraction was copy-pasted 3× with identical structure; now driven by a `STAT_SELECTORS` config dict
- **Move `stats = {}` initialization before `try` block** — prevents `UnboundLocalError` if an exception fires before the dict is created
- **Expand compressed single-line statements to multi-line** — `if x: y` on one line violates PEP 8 readability guidelines
- **Consistent double-quote style** throughout
- **Wrap long `USER_AGENT` string literal** for readability

### Testing
- Syntax validated with `ast.parse()` — no errors
- Functional behavior unchanged: same scraping logic, same placeholder replacement, same exit codes
